### PR TITLE
Eliminate Title Collision

### DIFF
--- a/rules/windows/process_creation/win_apt_bear_activity_gtr19.yml
+++ b/rules/windows/process_creation/win_apt_bear_activity_gtr19.yml
@@ -1,4 +1,4 @@
-title: Judgement Panda Exfil Activity
+title: Judgement Panda Credential Access Activity
 id: b83f5166-9237-4b5e-9cd4-7b5d52f4d8ee
 description: Detects Russian group activity as described in Global Threat Report 2019 by Crowdstrike
 references:


### PR DESCRIPTION
Title collision between

windows / process creation / win_apt_bear_activity_gtr19.yml

and 

windows / process creation / win_apt_judgement_panda_gtr19.yml

Causes Elastalert to fail during rules processing.