### PR TITLE
Eliminate Title Collision

### DIFF
--- a/rules/windows/process_creation/win_powershell_downgrade_attack.yml
+++ b/rules/windows/process_creation/win_powershell_downgrade_attack.yml
@@ -1,4 +1,4 @@
-title: PowerShell Downgrade Attack
+title: PowerShell Downgrade Attack - Version Checker
 id: b3512211-c67e-4707-bedc-66efc7848863
 related:
   - id: 6331d09b-4785-4c13-980f-f96661356249


### PR DESCRIPTION
Another title collision in the rules repo. 

rules/windows/powershell/powershell_downgrade_attack.yml
and
rules/windows/process_creation/win_powershell_downgrade_attack.yml

ended up with the same title (Powershell Downgrade Attack) which caused an Elastalert crash during rules processing.